### PR TITLE
add Stacktome to companies list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Grovo <https://grovo.com/>`_
 * `Weebly <https://www.weebly.com/>`_
 * `Deloitte <https://www.Deloitte.co.uk/>`_
+* `Stacktome <https://stacktome.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION
### Description
Hi there!   
We're stacktome team and now we're working on our product ["Automated Advertisement for Customer Retention"](https://stacktome.com/).  
Could you add stacktome.com to the list of companies who use luigi.   
We have built tasks for working with Google Cloud Storage and BigQuery, which written on luigi.

### Motivation and Context

Our luigi-extensions repository is [here](https://github.com/stacktome/luigi-extensions).
We love luigi! :heart:
 
Best regard,  
Stacktome team